### PR TITLE
#15 - Historic stock data and Run Now 

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,7 +12,6 @@ require 'net/http'
 
   def retrieve_current_data
     @item = Item.create(data: nil)
-    #ItemsWorker.perform_in(1.minutes, @item.id)
     ItemsWorker.perform_async(@item.id)
     @item.reload
     sleep(20)
@@ -23,6 +22,12 @@ require 'net/http'
   def search_history
     @search_item = params[:search]
     @history_data = Item.get_history_data(@search_item)
+  end
+
+  def start_capture
+  end
+
+  def stop_capture
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,9 +20,22 @@ require 'net/http'
   end
 
   def search_history
+    params[:search].present?
     @search_item = params[:search]
     @history_data = Item.get_history_data(@search_item)
   end
+
+  def search_all_history
+    @no_data = "Historic data does not exist for: "
+    @all_data = Array.new
+      Rails.configuration.stock_symbols.each do |stock|
+        @history_data = Item.get_history_data(stock)
+        @no_data.concat(' ' + stock) if @history_data == [] 
+        @all_data.push @history_data unless @history_data == []
+      end
+    flash[:info] = @no_data 
+  end
+
 
   def start_capture
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,4 +10,14 @@ class Item < ActiveRecord::Base
     @history_data = xml_data ["query"]["results"]["quote"] if xml_data.present?
   end
 
+  def self.form_url 
+    initial_url = 'https://query.yahooapis.com/v1/public/yql?q=select%20Name%2C%20LastTradePriceOnly%2C%20LastTradeDate%2C%20LastTradeWithTime%20from%20yahoo.finance.quotes%20where%20symbol%20in%20(%22'
+    Rails.configuration.stock_symbols.each do |h|
+      initial_url = [initial_url, h].join('')
+      initial_url = [initial_url, '%22%2C%20%22'].join('')
+    end
+    initial_url = [initial_url, '%22%20)&diagnostics=true&env=store%3A%2F%2Fdatatables.org%2Falltableswithkeys'].join('')  
+  end
+
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,14 @@ class Item < ActiveRecord::Base
     url = URI.parse(uri)
     data = Net::HTTP.get_response(url).body
     xml_data = Hash.from_xml(data)
-    @history_data = xml_data ["query"]["results"]["quote"] if xml_data.present?
+    if xml_data.present?
+      if xml_data ["query"]["results"].present?
+        @history_data = xml_data ["query"]["results"]["quote"] 
+      else 
+        @history_data = []
+      end
+    end
+  @history_data
   end
 
   def self.form_url 

--- a/app/views/items/retrieve_current_data.html.erb
+++ b/app/views/items/retrieve_current_data.html.erb
@@ -1,6 +1,17 @@
 <div class ="jumbotron">
   <h2> Current Prices </h2>
 </div> 
+<div class = "row">
+  <div class = "col-md-4">
+    <%=link_to 'Run Now', retrieve_data_path %>
+  </div>
+  <div class = "col-md-4">
+    <%=link_to 'Start Capture', start_capture_path %>
+  </div>
+  <div class = "col-md-4">
+    <%=link_to 'Stop Capture', stop_capture_path(self.jid) %>
+  </div>
+</div>
 <table class='table table-striped'>
   <thead>
     <tr>

--- a/app/views/items/retrieve_current_data.html.erb
+++ b/app/views/items/retrieve_current_data.html.erb
@@ -6,10 +6,10 @@
     <%=link_to 'Run Now', retrieve_data_path %>
   </div>
   <div class = "col-md-4">
-    <%=link_to 'Start Capture', start_capture_path %>
+    <%#=link_to 'Start Capture', start_capture_path %>
   </div>
   <div class = "col-md-4">
-    <%=link_to 'Stop Capture', stop_capture_path(self.jid) %>
+    <%#=link_to 'Stop Capture', stop_capture_path(self.jid) %>
   </div>
 </div>
 <table class='table table-striped'>

--- a/app/views/items/search_all_history.html.erb
+++ b/app/views/items/search_all_history.html.erb
@@ -1,0 +1,30 @@
+<div class ="jumbotron">
+  <h2> Historical Data </h2>
+  <h5> <%=@no_data%></h5>
+</div> 
+<table class='table table-striped'>
+  <thead>
+    <tr>
+      <th> Stock Symbol</th>
+      <th> Date</th>
+      <th> Open</th>
+      <th> Low </th>
+      <th> High </th>
+      <th> Close </th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @all_data.each_with_index do |item, index| %>
+    <% item.each_with_index do |data_item, i| %>
+    <tr> 
+      <td> <%= data_item['Symbol'] %> </td>
+      <td> <%= data_item['Date'] %> </td>
+      <td> <%= number_to_currency data_item['Open'] %> </td>
+      <td> <%= number_to_currency data_item['Low'] %> </td>
+      <td> <%= number_to_currency data_item['High'] %> </td>
+      <td> <%= number_to_currency data_item['Close'] %> </td>
+    </tr>
+    <%end%>
+  <%end%>
+  </tbody>
+</table>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,6 +15,8 @@
       <ul class="nav navbar-nav">
         <li class="active"><a href="#">Home</a></li>
         <li><%=link_to 'Current Prices', retrieve_data_path%></li>
+        <li><%=link_to 'Historic Prices', search_all_history_path%></li>
+
       </ul>
       <div class = "pull-right">
         <%= form_tag(search_history_path, :method => "get", id: "search-form") do %>

--- a/app/workers/items_worker.rb
+++ b/app/workers/items_worker.rb
@@ -8,7 +8,8 @@ class ItemsWorker
     return if cancelled?
     logger.info("Working along")
     @item = Item.find(item_id)
-    url = URI.parse('https://query.yahooapis.com/v1/public/yql?q=select%20Name%2C%20LastTradePriceOnly%2C%20LastTradeDate%2C%20LastTradeWithTime%20from%20yahoo.finance.quotes%20where%20symbol%20in%20(%22CLH16.NYM%22%2C%20%22BZJ16.NYM%22%2C%20%22HOH16.NYM%22%2C%20%22NGH16.NYM%22%2C%20%22RBH16.NYM%22%2C%20%22HGG16.CMX%22%2C%20%22GCG16.CMX%22%2C%20%22PAG16.NYM%22%2C%20%22PLH16.NYM%22%2C%20%22SIG16.CMX%22%20)&diagnostics=true&env=store%3A%2F%2Fdatatables.org%2Falltableswithkeys')
+    url_c = Item.form_url
+    url = URI.parse(url_c)
     data = Net::HTTP.get_response(url).body
     xml_data = Hash.from_xml(data)
     @quote_data = xml_data ["query"]["results"]["quote"] if xml_data.present?
@@ -23,4 +24,5 @@ class ItemsWorker
   def self.cancel!(jid)
     Sidekiq.redis {|c| c.setex("cancelled-#{jid}", 86400, 1) }
   end
+
 end

--- a/app/workers/items_worker.rb
+++ b/app/workers/items_worker.rb
@@ -2,8 +2,10 @@ require 'net/http'
 
 class ItemsWorker
   include Sidekiq::Worker
+  sidekiq_options unique_for: 10.minutes
 
   def perform(item_id)
+    return if cancelled?
     logger.info("Working along")
     @item = Item.find(item_id)
     url = URI.parse('https://query.yahooapis.com/v1/public/yql?q=select%20Name%2C%20LastTradePriceOnly%2C%20LastTradeDate%2C%20LastTradeWithTime%20from%20yahoo.finance.quotes%20where%20symbol%20in%20(%22CLH16.NYM%22%2C%20%22BZJ16.NYM%22%2C%20%22HOH16.NYM%22%2C%20%22NGH16.NYM%22%2C%20%22RBH16.NYM%22%2C%20%22HGG16.CMX%22%2C%20%22GCG16.CMX%22%2C%20%22PAG16.NYM%22%2C%20%22PLH16.NYM%22%2C%20%22SIG16.CMX%22%20)&diagnostics=true&env=store%3A%2F%2Fdatatables.org%2Falltableswithkeys')
@@ -14,4 +16,11 @@ class ItemsWorker
     @item.save
   end
 
+  def cancelled?
+    Sidekiq.redis {|c| c.exists("cancelled-#{jid}") }
+  end
+
+  def self.cancel!(jid)
+    Sidekiq.redis {|c| c.setex("cancelled-#{jid}", 86400, 1) }
+  end
 end

--- a/app/workers/items_worker.rb
+++ b/app/workers/items_worker.rb
@@ -6,10 +6,8 @@ class ItemsWorker
 
   def perform(item_id)
     return if cancelled?
-    logger.info("Working along")
     @item = Item.find(item_id)
-    url_c = Item.form_url
-    url = URI.parse(url_c)
+    url = URI.parse(Item.form_url)
     data = Net::HTTP.get_response(url).body
     xml_data = Hash.from_xml(data)
     @quote_data = xml_data ["query"]["results"]["quote"] if xml_data.present?

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
-  config.stock_symbols = ['SPK.NZ', 'BZJ16.NYM', 'HOH16.NYM', 'RBH16.NYM', 'HGG16.CMX', 'GCG16.CMX','PAG16.NYM', 'PLH16.NYM', 'SIG16.CMX']
+  config.stock_symbols = ['SPK.NZ', 'YHOO', 'HOH16.NYM', 'RBH16.NYM', 'HGG16.CMX', 'GCG16.CMX','PAG16.NYM', 'PLH16.NYM', 'SIG16.CMX']
   config.refresh_interval = 10.minutes
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,8 @@ Rails.application.configure do
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
-
+  config.stock_symbols = ['SPK.NZ', 'BZJ16.NYM', 'HOH16.NYM', 'RBH16.NYM', 'HGG16.CMX', 'GCG16.CMX','PAG16.NYM', 'PLH16.NYM', 'SIG16.CMX']
+  config.refresh_interval = 10.minutes
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,9 @@ require 'sidekiq/web'
 
 Rails.application.routes.draw do
    mount Sidekiq::Web, at: "/sidekiq"
-   root 'items#index'
+   root 'items#retrieve_current_data'
    get '/data' => 'items#retrieve_current_data', as: :retrieve_data
    get '/history' => 'items#search_history', as: :search_history
-
+   get 'items/stopcapture' => 'items#stop_capture', as: :stop_capture
+   get 'items/startcapture' => 'items#start_capture', as: :start_capture
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
    root 'items#retrieve_current_data'
    get '/data' => 'items#retrieve_current_data', as: :retrieve_data
    get '/history' => 'items#search_history', as: :search_history
+   get '/all_history' => 'items#search_all_history', as: :search_all_history
+
    get 'items/stopcapture' => 'items#stop_capture', as: :stop_capture
    get 'items/startcapture' => 'items#start_capture', as: :start_capture
 end


### PR DESCRIPTION
This pull request resolves #6, resolves #15 , resolves #13 

It adds a button to 'Run Now' for capturing purposes.
It also allows historical data to be displayed for all stocks on one page(if they exist)
It also sets up stocks to be defined in a file (rather than hardcoded)
General tidy up
